### PR TITLE
Remove deprecated experiement 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -170,7 +170,7 @@ resource "azurerm_subnet" "snet-ep" {
   resource_group_name                            = local.resource_group_name
   virtual_network_name                           = data.azurerm_virtual_network.vnet01.0.name
   address_prefixes                               = var.private_subnet_address_prefix
-  enforce_private_link_endpoint_network_policies = true
+  private_endpoint_network_policies_enabled      = true
 }
 
 resource "azurerm_private_endpoint" "pep1" {
@@ -225,21 +225,11 @@ resource "azurerm_monitor_diagnostic_setting" "acr-diag" {
     content {
       category = log.value
       enabled  = true
-
-      retention_policy {
-        enabled = false
-        days    = 0
-      }
     }
   }
 
   metric {
     category = "AllMetrics"
-
-    retention_policy {
-      enabled = false
-      days    = 0
-    }
   }
 
   lifecycle {

--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,9 @@
 terraform {
-  experiments = [module_variable_optional_attrs]
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
       version = ">= 2.59.0"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 1.3"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 2.59.0"
+      version = ">= 3.0"
     }
   }
   required_version = ">= 1.3"


### PR DESCRIPTION
Remove the deprecated experiment option, and increase the required terraform verison respectively. Is a breaking change, and should be released as v2.0.0